### PR TITLE
Replaced apex.amp with torch.cuda.amp and Tensor.view() with Tensor.reshape()

### DIFF
--- a/deepinversion.py
+++ b/deepinversion.py
@@ -16,7 +16,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import collections
-from apex import amp
+import torch.cuda.amp as amp
 import random
 import torch
 import torchvision.utils as vutils

--- a/imagenet_inversion.py
+++ b/imagenet_inversion.py
@@ -44,7 +44,7 @@ def validate_one(input, target, model):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0)
+            correct_k = correct[:k].reshape(-1).float().sum(0)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 

--- a/imagenet_inversion.py
+++ b/imagenet_inversion.py
@@ -22,7 +22,7 @@ import torch.utils.data
 from torchvision import datasets, transforms
 
 import numpy as np
-from apex import amp
+import torch.cuda.amp as amp
 import os
 import torchvision.models as models
 from utils.utils import load_model_pytorch, distributed_is_initialized


### PR DESCRIPTION
I cloned and run the code on Google Colab and I faced two problems:

The **first one** was caused by "apex.amp" and it was the following one:
`cannot import name 'UnencryptedCookieSessionFactoryConfig' from 'pyramid.session'`
I was able to run the code by replacing apex.amp with torch.cuda.amp in both deepinversion.py and imagenet_inversion.py

The **second one** was caused by Tensor.view():
`RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.`

So I replaced in imagenet_inversion.py (line 47) 
`correct_k = correct[:k].view(-1).float().sum(0)`
with 
`correct_k = correct[:k].reshape(-1).float().sum(0)`

Thanks to these two adjustements I was able to run the code without any further problems.