### PR TITLE
multi-gpu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Code was tested on NVIDIA V100 GPU and Titan X Pascal.
 
 This snippet will generate 84 images by inverting resnet50 model from torchvision package.
 
-`python imagenet_inversion.py --bs=84 --do_flip --exp_name="rn50_inversion" --r_feature=0.01 --arch_name="resnet50" --verifier --adi_scale=0.0 --setting_id=0 --lr 0.25`
+`python imagenet_inversion.py --bs=84 --do_flip --exp_name="rn50_inversion" --r_feature=0.01 --arch_name="resnet50" --verifier --adi_scale=0.0 --setting_id=0 --lr 0.25 --gpu_ids 0`
 
 Arguments:
 
@@ -61,6 +61,7 @@ Useful to observe generalizability of generated images.
 - `setting_id` - settings for optimization: 0 - multi resolution scheme, 1 - 2k iterations full resolution, 2 - 20k iterations (the closes to ResNet50 experiments in the paper). Recommended to use setting_id={0, 1}
 - `adi_scale` - competition coefficient. With positive value will lead to images that are good for the original model, but bad for verifier. Value 0.2 was used in the paper.
 - `random_label` - randomly select classes for inversion. Without this argument the code will generate hand picked classes.
+- `gpu_ids` - device ids for using single/multi-gpu training.
 
 After 3k iterations (~6 mins on NVIDIA V100) generation is done: `Verifier accuracy:  91.6...%` (experiment with >98% verifier accuracy can be found `/example_logs`). We generated images by inverting vanilla ResNet50 (not trained for image generation) and classification accuracy by MobileNetv2 is >90%. A grid of images look like (from `/final_images/`, reduced quality due to JPEG compression. )
 ![Generated grid of images](example_logs/fp32_set0_rn50_first_bn_scaled.jpg "ResNet50 Inverted images")

--- a/imagenet_inversion.py
+++ b/imagenet_inversion.py
@@ -168,7 +168,8 @@ def run(args):
                                              criterion=criterion,
                                              coefficients = coefficients,
                                              network_output_function = network_output_function,
-                                             hook_for_display = hook_for_display)
+                                             hook_for_display = hook_for_display,
+                                             gpus = args.gpu_ids)
     net_student=None
     if args.adi_scale != 0:
         net_student = net_verifier
@@ -186,7 +187,7 @@ def main():
     parser.add_argument('--bs', default=64, type=int, help='batch size')
     parser.add_argument('--jitter', default=30, type=int, help='batch size')
     parser.add_argument('--comment', default='', type=str, help='batch size')
-    parser.add_argument('--arch_name', default='resnet50', type=str, help='model name from torchvision or resnet50v15')
+    parser.add_argument('--arch_name', default='resnet101', type=str, help='model name from torchvision or resnet50v15')
 
     parser.add_argument('--fp16', action='store_true', help='use FP16 for optimization')
     parser.add_argument('--exp_name', type=str, default='test', help='where to store experimental data')
@@ -204,6 +205,7 @@ def main():
     parser.add_argument('--l2', type=float, default=0.00001, help='l2 loss on the image')
     parser.add_argument('--main_loss_multiplier', type=float, default=1.0, help='coefficient for the main loss in optimization')
     parser.add_argument('--store_best_images', action='store_true', help='save best images as separate files')
+    parser.add_argument('--gpu_ids', nargs='+', type=int, help='ids of gpus to be used')
 
     args = parser.parse_args()
     print(args)


### PR DESCRIPTION
Thank you very much for providing the code implementation!

I have made some adjustments to the `DeepInversionFeatureHook` and `DeepInversionClass` in `deepinversion.py`, to enable multi-gpu support.  In this version, the `r_feature` loss on each device is summed together to compute the total loss -- mean also works but I found that it required some adjustments to the lr.